### PR TITLE
Enable linear to sRGB colorspace conversion in framebuffer

### DIFF
--- a/projects/VoxelRenderer/src/main.cpp
+++ b/projects/VoxelRenderer/src/main.cpp
@@ -304,6 +304,7 @@ int main()
     double mouseWheel = 0;
 
     glfwSwapInterval(0); // disable vsync
+    glEnable(GL_FRAMEBUFFER_SRGB);
     glClearColor(0, 0, 0, 0);
 
     if (glfwRawMouseMotionSupported())


### PR DESCRIPTION
OpenGL seems to not perform linear to sRGB conversion when writing to the framebuffer by defau.t
Calling `glEnable(GL_FRAMEBUFFER_SRGB);` will properly handle linear to sRGB colorspace conversions when writing to the framebuffer. The reason for this is because this wasn't standardized historically and applications often implemented the conversion manually. Instead of enabling proper conversions by default, a flag was added in order to maintain backwards compatibility.

![image](https://github.com/user-attachments/assets/1036c5f8-a81e-4275-8303-e88870a8c3c0)

See the following:
https://trello.com/c/zKzcZH2T/33-2-research-default-opengl-colorspace
https://gamedev.stackexchange.com/questions/176717/why-is-enabling-gl-framebuffer-srgb-making-the-colours-brighter
https://unlimited3d.wordpress.com/2020/01/08/srgb-color-space-in-opengl/
https://registry.khronos.org/OpenGL/extensions/ARB/ARB_framebuffer_sRGB.txt