### PR TITLE
Improve events and add doc comments

### DIFF
--- a/projects/VoxelRenderer/src/BufferedEvent.h
+++ b/projects/VoxelRenderer/src/BufferedEvent.h
@@ -14,7 +14,10 @@ private:
     std::queue<std::tuple<TArgs...>> bufferedEvents;
 
 public:
+    // Raise an event, causing it to be added to the internal event buffer. To notify subscribers, call the flush() method.
     void raise(TArgs... args) override;
+
+    // Raises all buffered events, causing subscribers to be notified.
     void flush();
 };
 

--- a/projects/VoxelRenderer/src/Event.h
+++ b/projects/VoxelRenderer/src/Event.h
@@ -8,12 +8,33 @@ template <typename... TArgs>
 class Event
 {
 private:
-    std::vector<std::weak_ptr<std::function<void(TArgs...)>>> listeners;
+    // A list of all subscriptions, both externally owned and internally owned.
+    std::vector<std::weak_ptr<std::function<void(TArgs...)>>> subscriptions;
+
+    // A list of internally owned subscriptions.
+    std::vector<std::shared_ptr<std::function<void(TArgs...)>>> ownedSubscriptions;
+
     int recursionCount = 0;
 
 public:
-    virtual std::shared_ptr<std::function<void(TArgs...)>> subscribe(std::function<void(TArgs...)> listener);
+    // Add a function to be called when this event is raised.
+    // The returned shared pointer acts as a handle to the event subscription. The caller of the method owns the event subscription.
+    //
+    // When the shared pointer is reset or destroyed, the event subscription will be removed.
+    // Use this when you want to eventually unsubscribe from the event.
+    std::shared_ptr<std::function<void(TArgs...)>> subscribe(std::function<void(TArgs...)> listener);
 
+    // Add a function to be called when this event is raised.
+    // Unlike the subscribe() method, the event subscription is owned by the Event instance itself.
+    //
+    // Use this when you don't intend to unsubscribe from the event.
+    // Event subscriptions will still be cleaned up when the event class is destroyed.
+    void subscribePermanently(std::function<void(TArgs...)> listener);
+
+    // Clear all event subscriptions that were added through the subscribePermanently() method.
+    void clearPermanentSubscriptions();
+
+    // Raise an event, causing subscribers to be notified.
     virtual void raise(TArgs... args);
 };
 
@@ -21,9 +42,21 @@ template <typename... TArgs>
 std::shared_ptr<std::function<void(TArgs...)>> Event<TArgs...>::subscribe(std::function<void(TArgs...)> listener)
 {
     auto shared = std::make_shared<std::function<void(TArgs...)>>(listener);
-    listeners.push_back(shared);
+    subscriptions.push_back(shared);
 
     return shared;
+}
+
+template <typename... TArgs>
+void Event<TArgs...>::subscribePermanently(std::function<void(TArgs...)> listener)
+{
+    ownedSubscriptions.push_back(subscribe(listener));
+}
+
+template <typename... TArgs>
+void Event<TArgs...>::clearPermanentSubscriptions()
+{
+    ownedSubscriptions.clear();
 }
 
 template <typename... TArgs>
@@ -31,24 +64,31 @@ void Event<TArgs...>::raise(TArgs... args)
 {
     // Track recursion count because events can raise themselves
     recursionCount++;
-    for (std::weak_ptr<std::function<void(TArgs...)>> listener : listeners)
+    try
     {
-        auto shared = listener.lock();
-        if (shared)
+        for (std::weak_ptr<std::function<void(TArgs...)>> listener : subscriptions)
         {
-            (*shared)(args...);
+            auto shared = listener.lock();
+            if (shared)
+            {
+                (*shared)(args...);
+            }
         }
     }
-    recursionCount--;
+    catch (...)
+    {
+        recursionCount--;
+        throw;
+    };
 
     // Only remove entries from listeners list when no events are running
     if (recursionCount == 0)
     {
-        for (int i = listeners.size() - 1; i >= 0; --i)
+        for (int i = subscriptions.size() - 1; i >= 0; --i)
         {
-            if (listeners.at(i).expired())
+            if (subscriptions.at(i).expired())
             {
-                listeners.erase(listeners.begin() + i);
+                subscriptions.erase(subscriptions.begin() + i);
             }
         }
     }

--- a/projects/VoxelRenderer/src/InputManager.cpp
+++ b/projects/VoxelRenderer/src/InputManager.cpp
@@ -60,30 +60,30 @@ InputManager::InputManager(std::shared_ptr<Window> window)
     this->window = window;
     input = std::make_unique<Input>();
 
-    eventSubscriptions.push_back(window->keyEvent.subscribe([&](auto&&... args)
+    window->keyEvent.subscribePermanently([&](auto&&... args)
         {
             onKey(args...);
-        }));
+        });
 
-    eventSubscriptions.push_back(window->mouseButtonEvent.subscribe([&](auto&&... args)
+    window->mouseButtonEvent.subscribePermanently([&](auto&&... args)
         {
             onMouseButton(args...);
-        }));
+        });
 
-    eventSubscriptions.push_back(window->cursorPosEvent.subscribe([&](auto&&... args)
+    window->cursorPosEvent.subscribePermanently([&](auto&&... args)
         {
             onCursorPos(args...);
-        }));
+        });
 
-    eventSubscriptions.push_back(window->scrollEvent.subscribe([&](auto&&... args)
+    window->scrollEvent.subscribePermanently([&](auto&&... args)
         {
             onScroll(args...);
-        }));
+        });
 
-    eventSubscriptions.push_back(window->cursorEnterEvent.subscribe([&](auto&&... args)
+    window->cursorEnterEvent.subscribePermanently([&](auto&&... args)
         {
             onCursorEnter(args...);
-        }));
+        });
 }
 
 void InputManager::update()

--- a/projects/VoxelRenderer/src/InputManager.h
+++ b/projects/VoxelRenderer/src/InputManager.h
@@ -49,8 +49,6 @@ private:
     InputState next {};
     std::shared_ptr<Window> window;
 
-    std::vector<std::shared_ptr<void>> eventSubscriptions;
-
 public:
     std::unique_ptr<Input> input;
     bool cursorEnteredThisFrame = true;


### PR DESCRIPTION
subscribePermanently() allows users to subscribe to an event without worrying about having to manage the event subscription's lifetime.